### PR TITLE
sound: update header to v0.2.0

### DIFF
--- a/include/sound/compress_offload.h
+++ b/include/sound/compress_offload.h
@@ -21,7 +21,7 @@
 #include <linux/types.h>
 #include <sound/asound.h>
 #include <sound/compress_params.h>
-#define SNDRV_COMPRESS_VERSION SNDRV_PROTOCOL_VERSION(0, 1, 2)
+#define SNDRV_COMPRESS_VERSION SNDRV_PROTOCOL_VERSION(0, 2, 0)
 
 struct snd_compressed_buffer {
  __u32 fragment_size;

--- a/include/sound/compress_params.h
+++ b/include/sound/compress_params.h
@@ -39,8 +39,10 @@
 #define SND_AUDIOCODEC_G723_1 ((__u32) 0x0000000C)
 #define SND_AUDIOCODEC_G729 ((__u32) 0x0000000D)
 #define SND_AUDIOCODEC_BESPOKE ((__u32) 0x0000000E)
+#define SND_AUDIOCODEC_ALAC ((__u32) 0x0000000F)
+#define SND_AUDIOCODEC_APE ((__u32) 0x00000010)
 
-#define SND_AUDIOCODEC_MAX SND_AUDIOCODEC_BESPOKE
+#define SND_AUDIOCODEC_MAX SND_AUDIOCODEC_APE
 #define SND_AUDIOPROFILE_PCM ((__u32) 0x00000001)
 
 #define SND_AUDIOCHANMODE_MP3_MONO ((__u32) 0x00000001)
@@ -95,6 +97,10 @@
 #define SND_AUDIOPROFILE_WMA8 ((__u32) 0x00000002)
 #define SND_AUDIOPROFILE_WMA9 ((__u32) 0x00000004)
 #define SND_AUDIOPROFILE_WMA10 ((__u32) 0x00000008)
+#define SND_AUDIOPROFILE_WMA9_PRO ((__u32) 0x00000010)
+#define SND_AUDIOPROFILE_WMA9_LOSSLESS ((__u32) 0x00000020)
+#define SND_AUDIOPROFILE_WMA10_LOSSLESS ((__u32) 0x00000040)
+
 
 #define SND_AUDIOMODE_WMA_LEVEL1 ((__u32) 0x00000001)
 #define SND_AUDIOMODE_WMA_LEVEL2 ((__u32) 0x00000002)
@@ -207,6 +213,34 @@ struct snd_dec_flac {
  __u16 max_blk_size;
  __u16 min_frame_size;
  __u16 max_frame_size;
+ __u16 reserved;
+} __attribute__((packed, aligned(4)));
+
+struct snd_dec_wma {
+ __u32 encoder_option;
+ __u32 adv_encoder_option;
+ __u32 adv_encoder_option2;
+ __u32 reserved;
+} __attribute__((packed, aligned(4)));
+
+struct snd_dec_alac {
+ __u32 frame_length;
+ __u16 compatible_version;
+ __u16 max_run;
+ __u32 max_frame_bytes;
+ __u8 kb;
+ __u32 max_run;
+ __u32 max_frame_bytes;
+} __attribute__((packed, aligned(4)));
+
+struct snd_dec_ape {
+ __u16 compatible_version;
+ __u16 compression_level;
+ __u32 format_flags;
+ __u32 blocks_per_frame;
+ __u32 final_frame_blocks;
+ __u32 total_frames;
+ __u32 seek_table_present;
 } __attribute__((packed, aligned(4)));
 
 union snd_codec_options {
@@ -216,6 +250,9 @@ union snd_codec_options {
  struct snd_enc_flac flac;
  struct snd_enc_generic generic;
  struct snd_dec_flac flac_d;
+ struct snd_dec_wma wma_d;
+ struct snd_dec_alac alac_d;
+ struct snd_dec_ape ape_d;
 }__attribute__((packed, aligned(4)));
 
 struct snd_codec_desc {


### PR DESCRIPTION
Kernel has upgraded compress headers with support for WMA, ALAC and APE
and bumped version to 0.2.0, so update this header as well

Signed-off-by: Vinod Koul <vkoul@kernel.org>