### PR TITLE
Add support for WAVE file format in cplay

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -12,12 +12,20 @@ LT_INIT(disable-static)
 AC_ARG_ENABLE(fcplay,
   AS_HELP_STRING([--enable-fcplay], [enable the fcplay component]),
   [build_fcplay="$enableval"], [build_fcplay="no"])
+AC_ARG_ENABLE(pcm,
+  AS_HELP_STRING([--enable-pcm], [enable PCM compress playback support(used for debugging)]),
+  [enable_pcm="$enableval"], [enable_pcm="no"])
 
 AM_CONDITIONAL([BUILD_FCPLAY], [test x$build_fcplay = xyes])
+AM_CONDITIONAL([ENABLE_PCM], [test x$enable_pcm = xyes])
 
 #if test "$build_fcplay" = "yes"; then
 #  AC_DEFINE([BUILD_FCPLAY], "1", [Build Fcplay component])
 #fi
+
+if test "$enable_pcm" = "yes"; then
+  AC_DEFINE([ENABLE_PCM], 1, [Enable PCM compress playback support (used for debugging)])
+fi
 
 # Checks for programs.
 AC_PROG_CXX

--- a/include/tinycompress/tinywave.h
+++ b/include/tinycompress/tinywave.h
@@ -34,4 +34,8 @@ struct wave_header {
 	} __attribute__((__packed__)) data;
 } __attribute__((__packed__));
 
+void init_wave_header(struct wave_header *header, uint16_t channels,
+		      uint32_t rate, uint16_t samplebits);
+void size_wave_header(struct wave_header *header, uint32_t size);
+
 #endif

--- a/include/tinycompress/tinywave.h
+++ b/include/tinycompress/tinywave.h
@@ -1,0 +1,37 @@
+/* SPDX-License-Identifier: (LGPL-2.1-only OR BSD-3-Clause) */
+/*
+ * wave header and parsing
+ *
+ * Copyright 2020 NXP
+ */
+
+#ifndef __TINYWAVE_H
+#define __TINYWAVE_H
+
+struct riff_chunk {
+	char desc[4];
+	uint32_t size;
+} __attribute__((__packed__));
+
+struct wave_header {
+	struct {
+		struct riff_chunk chunk;
+		char format[4];
+	} __attribute__((__packed__)) riff;
+
+	struct {
+		struct riff_chunk chunk;
+		uint16_t type;
+		uint16_t channels;
+		uint32_t rate;
+		uint32_t byterate;
+		uint16_t blockalign;
+		uint16_t samplebits;
+	} __attribute__((__packed__)) fmt;
+
+	struct {
+		struct riff_chunk chunk;
+	} __attribute__((__packed__)) data;
+} __attribute__((__packed__));
+
+#endif

--- a/include/tinycompress/tinywave.h
+++ b/include/tinycompress/tinywave.h
@@ -38,4 +38,6 @@ void init_wave_header(struct wave_header *header, uint16_t channels,
 		      uint32_t rate, uint16_t samplebits);
 void size_wave_header(struct wave_header *header, uint32_t size);
 
+int parse_wave_header(struct wave_header *header, unsigned int *channels,
+		      unsigned int *rate, unsigned int *format);
 #endif

--- a/src/utils/Makefile.am
+++ b/src/utils/Makefile.am
@@ -1,6 +1,6 @@
 bin_PROGRAMS = cplay crecord
 
-cplay_SOURCES = cplay.c
+cplay_SOURCES = cplay.c wave.c
 crecord_SOURCES = crecord.c wave.c
 
 cplay_CFLAGS = -I$(top_srcdir)/include

--- a/src/utils/Makefile.am
+++ b/src/utils/Makefile.am
@@ -1,7 +1,7 @@
 bin_PROGRAMS = cplay crecord
 
 cplay_SOURCES = cplay.c
-crecord_SOURCES = crecord.c
+crecord_SOURCES = crecord.c wave.c
 
 cplay_CFLAGS = -I$(top_srcdir)/include
 crecord_CFLAGS = -I$(top_srcdir)/include

--- a/src/utils/crecord.c
+++ b/src/utils/crecord.c
@@ -77,6 +77,7 @@
 #include "sound/compress_params.h"
 #include "sound/compress_offload.h"
 #include "tinycompress/tinycompress.h"
+#include "tinycompress/tinywave.h"
 
 static int verbose;
 static int file;
@@ -111,32 +112,6 @@ static const struct {
 #endif
 };
 #define CREC_NUM_CODEC_IDS (sizeof(codec_ids) / sizeof(codec_ids[0]))
-
-struct riff_chunk {
-	char desc[4];
-	uint32_t size;
-} __attribute__((__packed__));
-
-struct wave_header {
-	struct {
-		struct riff_chunk chunk;
-		char format[4];
-	} __attribute__((__packed__)) riff;
-
-	struct {
-		struct riff_chunk chunk;
-		uint16_t type;
-		uint16_t channels;
-		uint32_t rate;
-		uint32_t byterate;
-		uint16_t blockalign;
-		uint16_t samplebits;
-	} __attribute__((__packed__)) fmt;
-
-	struct {
-		struct riff_chunk chunk;
-	} __attribute__((__packed__)) data;
-} __attribute__((__packed__));
 
 static const struct wave_header blank_wave_header = {
 	.riff = {

--- a/src/utils/crecord.c
+++ b/src/utils/crecord.c
@@ -113,47 +113,6 @@ static const struct {
 };
 #define CREC_NUM_CODEC_IDS (sizeof(codec_ids) / sizeof(codec_ids[0]))
 
-static const struct wave_header blank_wave_header = {
-	.riff = {
-		.chunk = {
-			.desc = "RIFF",
-		},
-		.format = "WAVE",
-	},
-	.fmt = {
-		.chunk = {
-			.desc = "fmt ", /* Note the space is important here */
-			.size = sizeof(blank_wave_header.fmt) -
-				sizeof(blank_wave_header.fmt.chunk),
-		},
-		.type = 0x01,   /* PCM */
-	},
-	.data = {
-		.chunk = {
-			.desc = "data",
-		},
-	},
-};
-
-static void init_wave_header(struct wave_header *header, uint16_t channels,
-			     uint32_t rate, uint16_t samplebits)
-{
-	memcpy(header, &blank_wave_header, sizeof(blank_wave_header));
-
-	header->fmt.channels = channels;
-	header->fmt.rate = rate;
-	header->fmt.byterate = channels * rate * (samplebits / 8);
-	header->fmt.blockalign = channels * (samplebits / 8);
-	header->fmt.samplebits = samplebits;
-}
-
-static void size_wave_header(struct wave_header *header, uint32_t size)
-{
-	header->riff.chunk.size = sizeof(*header) -
-				  sizeof(header->riff.chunk) + size;
-	header->data.chunk.size = size;
-}
-
 static const char *codec_name_from_id(unsigned int id)
 {
 	static char hexname[12];

--- a/src/utils/wave.c
+++ b/src/utils/wave.c
@@ -5,8 +5,10 @@
 //
 // Copyright 2021 NXP
 
+#include <stdio.h>
 #include <stdint.h>
 #include <string.h>
+#include <sound/asound.h>
 
 #include "tinycompress/tinywave.h"
 
@@ -49,4 +51,44 @@ void size_wave_header(struct wave_header *header, uint32_t size)
 	header->riff.chunk.size = sizeof(*header) -
 				  sizeof(header->riff.chunk) + size;
 	header->data.chunk.size = size;
+}
+
+int parse_wave_header(struct wave_header *header, unsigned int *channels,
+		      unsigned int *rate, unsigned int *format)
+{
+	if (strncmp(header->riff.chunk.desc, "RIFF", 4) != 0) {
+		fprintf(stderr, "RIFF magic not found\n");
+		return -1;
+	}
+
+	if (strncmp(header->riff.format, "WAVE", 4) != 0) {
+		fprintf(stderr, "WAVE magic not found\n");
+		return -1;
+	}
+
+	if (strncmp(header->fmt.chunk.desc, "fmt", 3) != 0) {
+		fprintf(stderr, "FMT section not found");
+		return -1;
+	}
+
+	*channels = header->fmt.channels;
+	*rate = header->fmt.rate;
+
+	switch(header->fmt.samplebits) {
+	case 8:
+		*format = SNDRV_PCM_FORMAT_U8;
+		break;
+	case 16:
+		*format = SNDRV_PCM_FORMAT_S16_LE;
+		break;
+	case 32:
+		*format = SNDRV_PCM_FORMAT_S32_LE;
+		break;
+	default:
+		fprintf(stderr, "Unsupported sample bits %d\n",
+			header->fmt.samplebits);
+		return -1;
+	}
+
+	return 0;
 }

--- a/src/utils/wave.c
+++ b/src/utils/wave.c
@@ -1,0 +1,52 @@
+//SPDX-License-Identifier: (LGPL-2.1-only OR BSD-3-Clause)
+
+//
+// WAVE helper functions
+//
+// Copyright 2021 NXP
+
+#include <stdint.h>
+#include <string.h>
+
+#include "tinycompress/tinywave.h"
+
+static const struct wave_header blank_wave_header = {
+	.riff = {
+		.chunk = {
+			.desc = "RIFF",
+		},
+		.format = "WAVE",
+	},
+	.fmt = {
+		.chunk = {
+			.desc = "fmt ", /* Note the space is important here */
+			.size = sizeof(blank_wave_header.fmt) -
+				sizeof(blank_wave_header.fmt.chunk),
+		},
+		.type = 0x01,   /* PCM */
+	},
+	.data = {
+		.chunk = {
+			.desc = "data",
+		},
+	},
+};
+
+void init_wave_header(struct wave_header *header, uint16_t channels,
+		      uint32_t rate, uint16_t samplebits)
+{
+	memcpy(header, &blank_wave_header, sizeof(blank_wave_header));
+
+	header->fmt.channels = channels;
+	header->fmt.rate = rate;
+	header->fmt.byterate = channels * rate * (samplebits / 8);
+	header->fmt.blockalign = channels * (samplebits / 8);
+	header->fmt.samplebits = samplebits;
+}
+
+void size_wave_header(struct wave_header *header, uint32_t size)
+{
+	header->riff.chunk.size = sizeof(*header) -
+				  sizeof(header->riff.chunk) + size;
+	header->data.chunk.size = size;
+}


### PR DESCRIPTION
This will allow us to use PCM codec type with cplay. This patchseries moves some WAVE related functions and structures to their own file in order to be used by both cplay/crecord.