### PR TITLE
Add support for getting list of supported codecs

### DIFF
--- a/include/tinycompress/compress_ops.h
+++ b/include/tinycompress/compress_ops.h
@@ -42,6 +42,7 @@ struct compress_ops {
 	int (*is_compress_running)(void *compress_data);
 	int (*is_compress_ready)(void *compress_data);
 	const char *(*get_error)(void *compress_data);
+	int (*get_supported_codecs_by_name)(const char *name, unsigned int flags, void *codecs, unsigned int size);
 };
 
 #endif /* end of __COMPRESS_OPS_H__ */

--- a/include/tinycompress/tinycompress.h
+++ b/include/tinycompress/tinycompress.h
@@ -307,6 +307,23 @@ int is_compress_ready(struct compress *compress);
 /* Returns a human readable reason for the last error */
 const char *compress_get_error(struct compress *compress);
 
+/*
+ * compress_get_supported_codecs_by_name: gets the list of supported codecs
+ *
+ * returns number of codecs on success, negative on error
+ *
+ * format of name is :
+ *    hw:<card>,<device> for real hw compress node
+ *    <plugin_libname>:<custom string> for virtual compress node
+ *
+ * @name: name of the compress node
+ * @flags: stream flags
+ * @codecs: Pointer to an array which will hold the list of codecs
+ * @size: Size in bytes of the codecs array
+ */
+int compress_get_supported_codecs_by_name(const char *name, unsigned int flags,
+		unsigned int *codecs, unsigned int size);
+
 #if defined(__cplusplus)
 } // extern "C"
 #endif

--- a/src/lib/compress.c
+++ b/src/lib/compress.c
@@ -310,3 +310,30 @@ int compress_wait(struct compress *compress, int timeout_ms)
 	return compress->ops->wait(compress->data, timeout_ms);
 }
 
+int compress_get_supported_codecs_by_name(const char *name, unsigned int flags,
+		unsigned int *codecs, unsigned int size)
+{
+	struct compress *compress;
+	int ret = -1;
+
+	compress = calloc(1, sizeof(struct compress));
+	if (!compress)
+		return ret;
+
+	if ((name[0] == 'h') || (name[1] == 'w') || (name[2] == ':')) {
+		compress->ops = &compress_hw_ops;
+	} else {
+		if (populate_compress_plugin_ops(compress, name)) {
+			free(compress);
+			return ret;
+		}
+	}
+
+	ret = compress->ops->get_supported_codecs_by_name(name, flags, codecs, size);
+
+	if (compress->dl_hdl)
+		dlclose(compress->dl_hdl);
+	free(compress);
+
+	return ret;
+}


### PR DESCRIPTION
Right now, there is no way to expose a list of codecs from `tinycompress`. While one could theoretically call `is_codec_supported` multiple times in an application to check against a list of codecs, an API would make it easy to enumerate supported codecs. The IOCTL `SNDRV_COMPRESS_GET_CAPS` after all already exists.

Our use case is Pipewire where we would like the compressed sink node to advertise only codecs supported by the underlying hardware. So far we were just advertising the complete list of codecs and let node linking fail at runtime based on result from `is_codec_supported`. 

Pipewire MR: https://gitlab.freedesktop.org/pipewire/pipewire/-/merge_requests/1431