### PR TITLE
Clean the warnings in cplay

### DIFF
--- a/src/utils/cplay.c
+++ b/src/utils/cplay.c
@@ -88,7 +88,6 @@ enum {
 static int verbose, interactive;
 static bool is_paused = false;
 static long term_c_lflag = -1, stdin_flags = -1;
-static const unsigned int DEFAULT_CODEC_ID = SND_AUDIOCODEC_PCM;
 
 static const struct {
 	const char *name;
@@ -363,8 +362,6 @@ int find_adif_header(FILE *file, unsigned int *num_channels, unsigned int *sampl
 	unsigned char adif_id[4];
 	unsigned char adif_header[20];
 	int bitstream_type;
-	int bitrate;
-	int object_type;
 	int sr_index;
 	int skip_size = 0;
 
@@ -385,23 +382,14 @@ int find_adif_header(FILE *file, unsigned int *num_channels, unsigned int *sampl
 		skip_size = 9;
 
 	bitstream_type = adif_header[0 + skip_size] & 0x10;
-	bitrate =
-		 ((unsigned int) (adif_header[0 + skip_size] & 0x0f) << 19) |
-		 ((unsigned int) adif_header[1 + skip_size] << 11) |
-		 ((unsigned int) adif_header[2 + skip_size] << 3) |
-		 ((unsigned int) adif_header[3 + skip_size] & 0xe0);
 
-	if (bitstream_type == 0) {
-		object_type = ((adif_header[6 + skip_size] & 0x01) << 1) |
-			((adif_header[7 + skip_size] & 0x80) >> 7);
+	if (bitstream_type == 0)
 		sr_index = (adif_header[7 + skip_size] & 0x78) >> 3;
-	}
+
 	/* VBR */
-	else {
-		object_type = (adif_header[4 + skip_size] & 0x18) >> 3;
+	else
 		sr_index = ((adif_header[4 + skip_size] & 0x07) << 1) |
 			((adif_header[5 + skip_size] & 0x80) >> 7);
-	}
 
 	/* sample rate */
 	*sample_rate = get_sample_rate_from_index(sr_index);

--- a/src/utils/cplay.c
+++ b/src/utils/cplay.c
@@ -255,7 +255,7 @@ int find_adts_header(FILE *file, unsigned int *num_channels, unsigned int *sampl
 	}
 	fseek(file, 0, SEEK_SET);
 
-	if ((buf[0] != 0xff) || (buf[1] & 0xf0 != 0xf0))
+	if ((buf[0] != 0xff) || ((buf[1] & 0xf0) != 0xf0))
 		return 0;
 	/* mpeg id */
 	switch (buf[1]>>3 & 0x1) {


### PR DESCRIPTION
cplay.c: In function ‘find_adts_header’:
cplay.c:259:41: warning: suggest parentheses around comparison in operand of ‘&’ [-Wparentheses]
  259 |         if ((buf[0] != 0xff) || (buf[1] & 0xf0 != 0xf0))
      |                                         ^
cplay.c: In function ‘find_adif_header’:
cplay.c:367:13: warning: variable ‘object_type’ set but not used [-Wunused-but-set-variable]
  367 |         int object_type;
      |             ^~~~~~~~~~~
cplay.c:366:13: warning: variable ‘bitrate’ set but not used [-Wunused-but-set-variable]
  366 |         int bitrate;
      |             ^~~~~~~
cplay.c: At top level:
cplay.c:91:27: warning: ‘DEFAULT_CODEC_ID’ defined but not used [-Wunused-const-variable=]
   91 | static const unsigned int DEFAULT_CODEC_ID = SND_AUDIOCODEC_PCM;
      |                           ^~~~~~~~~~~~~~~~

This resolves above warnings