### PR TITLE
wave: add <time.h> missing header inclusion

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2,7 +2,7 @@
 # Process this file with autoconf to produce a configure script.
 
 AC_PREREQ([2.63])
-AC_INIT([tinycompress], [1.2.5])
+AC_INIT([tinycompress], [1.2.8])
 AC_CONFIG_HEADERS([config.h])
 AC_CONFIG_MACRO_DIR([m4])
 

--- a/src/utils/wave.c
+++ b/src/utils/wave.c
@@ -8,6 +8,7 @@
 #include <stdio.h>
 #include <stdint.h>
 #include <string.h>
+#include <time.h>
 #include <sound/asound.h>
 
 #include "tinycompress/tinywave.h"


### PR DESCRIPTION
When compiling tinycompress with some libc other than glibc (e.g. musl libc), compilation fails with the following error:
    
    In file included from wave.c:11:0:
    /path/to/gcc/sysroot/usr/include/sound/asound.h:404:18: error: field 'trigger_tstamp' has incomplete type
      struct timespec trigger_tstamp; /* time when stream was started/stopped/paused */
    [...]
    
According to POSIX, `struct timespec` is defined in `<time.h>`. See: https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/time.h.html
    
This patch fixes this build failure by including `<time.h>` prior `<sound/asound.h>`.

Note: the github master branch is currently not including the tag 1.2.8, which is why my pull-request is also showing commit 750ebbe.