### PR TITLE
Fix build with FFmpeg 7

### DIFF
--- a/src/utils-lgpl/fcplay.c
+++ b/src/utils-lgpl/fcplay.c
@@ -240,8 +240,8 @@ static int parse_file(char *file, struct snd_codec *codec)
 			if (!filled) {
 				/* we fill params from 1st audio stream */
 				codec->id = get_codec_id(stream->codecpar->codec_id);
-				codec->ch_in = stream->codecpar->channels;
-				codec->ch_out = stream->codecpar->channels;
+				codec->ch_in = stream->codecpar->ch_layout.nb_channels;
+				codec->ch_out = stream->codecpar->ch_layout.nb_channels;
 				codec->sample_rate = stream->codecpar->sample_rate;
 				codec->bit_rate = ctx->bit_rate;
 				codec->profile = stream->codecpar->profile;
@@ -273,7 +273,7 @@ static int parse_file(char *file, struct snd_codec *codec)
 				fprintf(stderr, "  Bits coded: %d", stream->codecpar->bits_per_coded_sample);
 				fprintf(stderr, "  Profile: %d", stream->codecpar->profile);
 				fprintf(stderr, "  Codec tag: %d", stream->codecpar->codec_tag);
-				fprintf(stderr, "  Channels: %d", stream->codecpar->channels);
+				fprintf(stderr, "  Channels: %d", stream->codecpar->ch_layout.nb_channels);
 				fprintf(stderr, "  Sample rate: %d", stream->codecpar->sample_rate);
 				fprintf(stderr, "  block_align: %d", stream->codecpar->block_align);
 				if (codec->id == SND_AUDIOCODEC_FLAC) {


### PR DESCRIPTION
Patch provided by the Arch Linux team: https://gitlab.archlinux.org/archlinux/packaging/packages/tinycompress/-/blob/main/0001-Fix-build-with-FFmpeg-7.patch