### PR TITLE
include: install compress_ops.h as public header

### DIFF
--- a/include/Makefile.am
+++ b/include/Makefile.am
@@ -1,8 +1,8 @@
-nobase_include_HEADERS = tinycompress/tinycompress.h
+nobase_include_HEADERS = tinycompress/tinycompress.h \
+                         tinycompress/compress_ops.h
 
 noinst_HEADERS = sound/compress_offload.h \
 		 sound/compress_params.h \
 		 tinycompress/version.h \
-		 tinycompress/compress_ops.h \
 		 tinycompress/tinymp3.h \
 		 tinycompress/tinywave.h


### PR DESCRIPTION
Move tinycompress/compress_ops.h from noinst_HEADERS to nobase_include_HEADERS so it gets installed for users.