### PR TITLE
Cleanups for the tstamp64 merge + make external plugin interface more robust

### DIFF
--- a/include/tinycompress/compress_ops.h
+++ b/include/tinycompress/compress_ops.h
@@ -8,6 +8,8 @@
 #include "sound/compress_offload.h"
 #include "tinycompress.h"
 
+#define COMPRESS_OPS_V2		0xadcc0002	/* version 2 magic */
+
 /*
  * struct compress_ops:
  * ops structure containing ops corresponding to exposed
@@ -16,6 +18,7 @@
  * done in compress_hw.c
  */
 struct compress_ops {
+	unsigned int magic;	/* version of this structure */
 	void *(*open_by_name)(const char *name,
 			unsigned int flags, struct compr_config *config);
 	void (*close)(void *compress_data);

--- a/include/tinycompress/compress_ops.h
+++ b/include/tinycompress/compress_ops.h
@@ -25,8 +25,6 @@ struct compress_ops {
 	int (*get_hpointer)(void *compress_data,
 			unsigned int *avail, struct timespec *tstamp);
 	int (*get_tstamp)(void *compress_data,
-			unsigned int *samples, unsigned int *sampling_rate);
-	int (*get_tstamp64)(void *compress_data,
 			unsigned long long *samples, unsigned int *sampling_rate);
 	int (*write)(void *compress_data, const void *buf, size_t size);
 	int (*read)(void *compress_data, void *buf, size_t size);

--- a/include/tinycompress/compress_ops.h
+++ b/include/tinycompress/compress_ops.h
@@ -23,7 +23,7 @@ struct compress_ops {
 			unsigned int flags, struct compr_config *config);
 	void (*close)(void *compress_data);
 	int (*get_hpointer)(void *compress_data,
-			unsigned int *avail, struct timespec *tstamp);
+			unsigned long long *avail, struct timespec *tstamp);
 	int (*get_tstamp)(void *compress_data,
 			unsigned long long *samples, unsigned int *sampling_rate);
 	int (*write)(void *compress_data, const void *buf, size_t size);

--- a/include/tinycompress/tinycompress.h
+++ b/include/tinycompress/tinycompress.h
@@ -140,6 +140,18 @@ int compress_get_hpointer(struct compress *compress,
 
 
 /*
+ * compress_get_hpointe64r: get the hw timestamp
+ * return 0 on success, negative on error
+ *
+ * @compress: compress stream on which query is made
+ * @avail: buffer availble for write/read, in bytes
+ * @tstamp: hw time
+ */
+int compress_get_hpointer64(struct compress *compress,
+		unsigned long long *avail, struct timespec *tstamp);
+
+
+/*
  * compress_get_tstamp: get the raw hw timestamp
  * return 0 on success, negative on error
  *

--- a/src/lib/compress.c
+++ b/src/lib/compress.c
@@ -209,13 +209,19 @@ int compress_get_hpointer(struct compress *compress,
 int compress_get_tstamp(struct compress *compress,
 			unsigned int *samples, unsigned int *sampling_rate)
 {
-	return compress->ops->get_tstamp(compress->data, samples, sampling_rate);
+	unsigned long long _samples;
+	int ret;
+
+	ret = compress->ops->get_tstamp(compress->data, &_samples, sampling_rate);
+	if (ret >= 0)
+		*samples = (unsigned int)_samples;
+	return ret;
 }
 
 int compress_get_tstamp64(struct compress *compress,
 			unsigned long long *samples, unsigned int *sampling_rate)
 {
-	return compress->ops->get_tstamp64(compress->data, samples, sampling_rate);
+	return compress->ops->get_tstamp(compress->data, samples, sampling_rate);
 }
 
 int compress_write(struct compress *compress, const void *buf, unsigned int size)

--- a/src/lib/compress.c
+++ b/src/lib/compress.c
@@ -58,6 +58,7 @@
 #include <dlfcn.h>
 #include <stdio.h>
 #include <string.h>
+#include <limits.h>
 #include <sys/errno.h>
 #include <sys/time.h>
 #include "tinycompress/tinycompress.h"
@@ -202,6 +203,21 @@ void compress_close(struct compress *compress)
 
 int compress_get_hpointer(struct compress *compress,
 		unsigned int *avail, struct timespec *tstamp)
+{
+	unsigned long long _avail;
+	int ret;
+
+	ret = compress->ops->get_hpointer(compress->data, &_avail, tstamp);
+	if (ret >= 0) {
+		if (_avail > UINT_MAX)
+			_avail = UINT_MAX;
+		*avail = (unsigned int)_avail;
+	}
+	return ret;
+}
+
+int compress_get_hpointer64(struct compress *compress,
+		unsigned long long *avail, struct timespec *tstamp)
 {
 	return compress->ops->get_hpointer(compress->data, avail, tstamp);
 }

--- a/src/lib/compress_hw.c
+++ b/src/lib/compress_hw.c
@@ -641,6 +641,7 @@ static int compress_hw_set_codec_params(void *data, struct snd_codec *codec)
 }
 
 struct compress_ops compress_hw_ops = {
+	.magic = COMPRESS_OPS_V2,
 	.open_by_name = compress_hw_open_by_name,
 	.close = compress_hw_close,
 	.get_hpointer = compress_hw_get_hpointer,

--- a/src/lib/compress_hw.c
+++ b/src/lib/compress_hw.c
@@ -237,7 +237,7 @@ static void compress_hw_avail64_from_32(struct snd_compr_avail64 *avail64,
 }
 
 static int compress_hw_get_hpointer(void *data,
-		unsigned int *avail, struct timespec *tstamp)
+		unsigned long long *avail, struct timespec *tstamp)
 {
 	struct compress_hw_data *compress = (struct compress_hw_data *)data;
 	struct snd_compr_avail kavail32;
@@ -263,7 +263,7 @@ static int compress_hw_get_hpointer(void *data,
 
 	if (0 == kavail64.tstamp.sampling_rate)
 		return oops(compress, ENODATA, "sample rate unknown");
-	*avail = (unsigned int)kavail64.avail;
+	*avail = kavail64.avail;
 	time = kavail64.tstamp.pcm_io_frames / kavail64.tstamp.sampling_rate;
 	tstamp->tv_sec = time;
 	time = kavail64.tstamp.pcm_io_frames % kavail64.tstamp.sampling_rate;

--- a/src/lib/compress_hw.c
+++ b/src/lib/compress_hw.c
@@ -225,14 +225,15 @@ static void compress_hw_close(void *data)
 }
 
 static void compress_hw_avail64_from_32(struct snd_compr_avail64 *avail64,
-                                        const struct snd_compr_avail *avail32) {
-  avail64->avail = avail32->avail;
+					const struct snd_compr_avail *avail32)
+{
+	avail64->avail = avail32->avail;
 
-  avail64->tstamp.byte_offset = avail32->tstamp.byte_offset;
-  avail64->tstamp.copied_total = avail32->tstamp.copied_total;
-  avail64->tstamp.pcm_frames = avail32->tstamp.pcm_frames;
-  avail64->tstamp.pcm_io_frames = avail32->tstamp.pcm_io_frames;
-  avail64->tstamp.sampling_rate = avail32->tstamp.sampling_rate;
+	avail64->tstamp.byte_offset = avail32->tstamp.byte_offset;
+	avail64->tstamp.copied_total = avail32->tstamp.copied_total;
+	avail64->tstamp.pcm_frames = avail32->tstamp.pcm_frames;
+	avail64->tstamp.pcm_io_frames = avail32->tstamp.pcm_io_frames;
+	avail64->tstamp.sampling_rate = avail32->tstamp.sampling_rate;
 }
 
 static int compress_hw_get_hpointer(void *data,


### PR DESCRIPTION
This is a follow up for #29 and #30. Comments are welcome.