### PR TITLE
fcplay/cplay: Improve information printout regarding to buffer configuration and track playback progression

### DIFF
--- a/include/tinycompress/tinycompress.h
+++ b/include/tinycompress/tinycompress.h
@@ -334,7 +334,8 @@ const char *compress_get_error(struct compress *compress);
 
 /* Prints basic stream details for playback diagnostics */
 void compress_print_playback_info(const char *name, unsigned int card,
-		unsigned int device, unsigned long buffer_size,
+		unsigned int device, unsigned int file_count,
+		unsigned int file_idx, unsigned long buffer_size,
 		unsigned int num_fragments, const struct snd_codec *codec);
 
 /*

--- a/include/tinycompress/tinycompress.h
+++ b/include/tinycompress/tinycompress.h
@@ -332,6 +332,11 @@ int is_compress_ready(struct compress *compress);
 /* Returns a human readable reason for the last error */
 const char *compress_get_error(struct compress *compress);
 
+/* Prints basic stream details for playback diagnostics */
+void compress_print_playback_info(const char *name, unsigned int card,
+		unsigned int device, unsigned long buffer_size,
+		unsigned int num_fragments, const struct snd_codec *codec);
+
 /*
  * compress_set_param: set codec config intended for next track
  * if DSP has support to switch CODEC config during gapless playback

--- a/src/lib/compress.c
+++ b/src/lib/compress.c
@@ -82,10 +82,15 @@ const char *compress_get_error(struct compress *compress)
 }
 
 void compress_print_playback_info(const char *name, unsigned int card,
-		unsigned int device, unsigned long buffer_size,
+		unsigned int device, unsigned int file_count,
+		unsigned int file_idx, unsigned long buffer_size,
 		unsigned int num_fragments, const struct snd_codec *codec)
 {
-	printf("Playing file %s On Card %u device %u\n", name, card, device);
+	if (file_count > 1)
+		printf("Playing file %u/%u %s On Card %u device %u\n", file_idx + 1,
+		       file_count, name, card, device);
+	else
+		printf("Playing file %s On Card %u device %u\n", name, card, device);
 	printf(" Buffer size: %lu bytes, %u fragments, fragment size: %lu bytes\n",
 	       buffer_size, num_fragments, buffer_size / num_fragments);
 	printf(" Format %u Channels %u, %u Hz, Bit Rate %d\n",

--- a/src/lib/compress.c
+++ b/src/lib/compress.c
@@ -81,6 +81,17 @@ const char *compress_get_error(struct compress *compress)
 	return compress->ops->get_error(compress->data);
 }
 
+void compress_print_playback_info(const char *name, unsigned int card,
+		unsigned int device, unsigned long buffer_size,
+		unsigned int num_fragments, const struct snd_codec *codec)
+{
+	printf("Playing file %s On Card %u device %u\n", name, card, device);
+	printf(" Buffer size: %lu bytes, %u fragments, fragment size: %lu bytes\n",
+	       buffer_size, num_fragments, buffer_size / num_fragments);
+	printf(" Format %u Channels %u, %u Hz, Bit Rate %d\n",
+		codec->id, codec->ch_in, codec->sample_rate, (int)codec->bit_rate);
+}
+
 int is_compress_running(struct compress *compress)
 {
 	return compress->ops->is_compress_running(compress->data);

--- a/src/utils-lgpl/fcplay.c
+++ b/src/utils-lgpl/fcplay.c
@@ -352,11 +352,12 @@ static struct compress *
 compress_open_and_prepare(unsigned int card, unsigned int device,
 			  struct snd_codec *codec, unsigned long buffer_size,
 			  unsigned int frag, const char *name, FILE *file,
-			  char **buffer_out, int *size_out)
+			  char **buffer_out, unsigned long *total_size_out,
+			  unsigned int *num_fragments_out)
 {
 	struct compr_config config;
 	struct compress *compress;
-	int size, num_read, wrote;
+	int fragment_size, num_read, wrote;
 	char *buffer;
 
 	memset(&config, 0, sizeof(config));
@@ -381,17 +382,17 @@ compress_open_and_prepare(unsigned int card, unsigned int device,
 	if (verbose)
 		printf("%s: Opened compress device\n", __func__);
 
-	size = config.fragment_size;
-	buffer = malloc(size * config.fragments);
+	fragment_size = config.fragment_size;
+	buffer = malloc(fragment_size * config.fragments);
 	if (!buffer) {
 		fprintf(stderr, "Unable to allocate %d bytes\n",
-			size * config.fragments);
+			fragment_size * config.fragments);
 		compress_close(compress);
 		return NULL;
 	}
 
 	/* write full buffer data initially */
-	num_read = fread(buffer, 1, size * config.fragments, file);
+	num_read = fread(buffer, 1, fragment_size * config.fragments, file);
 	if (num_read > 0) {
 		if (verbose)
 			printf("%s: Doing first buffer write of %d\n", __func__, num_read);
@@ -410,7 +411,8 @@ compress_open_and_prepare(unsigned int card, unsigned int device,
 	}
 
 	*buffer_out = buffer;
-	*size_out = size;
+	*total_size_out = (unsigned long)fragment_size * config.fragments;
+	*num_fragments_out = config.fragments;
 	return compress;
 }
 
@@ -421,7 +423,9 @@ void play_samples(char **files, unsigned int card, unsigned int device,
 {
 	struct compr_gapless_mdata mdata;
 	struct compress *compress;
-	int size, num_read, wrote;
+	int fragment_size, num_read, wrote;
+	unsigned long allocated_buffer_size;
+	unsigned int num_fragments;
 	unsigned int file_idx = 0;
 	struct snd_codec codec;
 	char *buffer, *name;
@@ -436,17 +440,20 @@ void play_samples(char **files, unsigned int card, unsigned int device,
 
 	parse_file(name, &codec);
 	compress = compress_open_and_prepare(card, device, &codec, buffer_size,
-					     frag, name, file, &buffer, &size);
+					     frag, name, file, &buffer,
+					     &allocated_buffer_size, &num_fragments);
 	if (!compress)
 		goto FILE_EXIT;
+
+	fragment_size = (int)(allocated_buffer_size / num_fragments);
 
 	if (pb_mode == PLAYBACK_MODE_GAPLESS) {
 		memset(&mdata, 0, sizeof(mdata));
 		compress_set_gapless_metadata(compress, &mdata);
 	}
 
-	printf("Playing file %s On Card %u device %u, with buffer of %lu bytes\n",
-			name, card, device, buffer_size);
+	printf("Playing file %s On Card %u device %u, with buffer of %lu bytes, %u fragments\n",
+			name, card, device, allocated_buffer_size, num_fragments);
 	printf("Format %u Channels %u, %u Hz, Bit Rate %d\n",
 			codec.id, codec.ch_in, codec.sample_rate, codec.bit_rate);
 
@@ -462,8 +469,8 @@ void play_samples(char **files, unsigned int card, unsigned int device,
 				goto TRACK_EXIT;
 
 			if (verbose)
-				printf("Playing file %s On Card %u device %u, with buffer of %lu bytes\n",
-					    name, card, device, buffer_size);
+				printf("Playing file %s On Card %u device %u, with buffer of %lu bytes, %u fragments\n",
+				       name, card, device, allocated_buffer_size, num_fragments);
 
 			if (pb_mode == PLAYBACK_MODE_GAPLESS) {
 				int rc;
@@ -495,12 +502,16 @@ void play_samples(char **files, unsigned int card, unsigned int device,
 				parse_file(name, &codec);
 				compress = compress_open_and_prepare(card, device, &codec,
 								     buffer_size, frag, name,
-								     file, &buffer, &size);
+								     file, &buffer,
+								     &allocated_buffer_size,
+								     &num_fragments);
 				if (!compress)
 					goto FILE_EXIT;
 
-				printf("Playing file %s On Card %u device %u, with buffer of %lu bytes\n",
-					name, card, device, buffer_size);
+				fragment_size = num_fragments ? (int)(allocated_buffer_size / num_fragments) : 0;
+
+				printf("Playing file %s On Card %u device %u, with buffer of %lu bytes, %u fragments\n",
+					name, card, device, allocated_buffer_size, num_fragments);
 				printf("Format %u Channels %u, %u Hz, Bit Rate %d\n",
 					codec.id, codec.ch_in, codec.sample_rate, codec.bit_rate);
 
@@ -511,7 +522,7 @@ void play_samples(char **files, unsigned int card, unsigned int device,
 		}
 
 		do {
-			num_read = fread(buffer, 1, size, file);
+			num_read = fread(buffer, 1, fragment_size, file);
 			if (num_read > 0) {
 				wrote = compress_write(compress, buffer, num_read);
 				if (wrote < 0) {

--- a/src/utils-lgpl/fcplay.c
+++ b/src/utils-lgpl/fcplay.c
@@ -452,10 +452,8 @@ void play_samples(char **files, unsigned int card, unsigned int device,
 		compress_set_gapless_metadata(compress, &mdata);
 	}
 
-	printf("Playing file %s On Card %u device %u, with buffer of %lu bytes, %u fragments\n",
-			name, card, device, allocated_buffer_size, num_fragments);
-	printf("Format %u Channels %u, %u Hz, Bit Rate %d\n",
-			codec.id, codec.ch_in, codec.sample_rate, codec.bit_rate);
+	compress_print_playback_info(name, card, device, allocated_buffer_size,
+				     num_fragments, &codec);
 
 	compress_start(compress);
 	if (verbose)
@@ -510,10 +508,9 @@ void play_samples(char **files, unsigned int card, unsigned int device,
 
 				fragment_size = num_fragments ? (int)(allocated_buffer_size / num_fragments) : 0;
 
-				printf("Playing file %s On Card %u device %u, with buffer of %lu bytes, %u fragments\n",
-					name, card, device, allocated_buffer_size, num_fragments);
-				printf("Format %u Channels %u, %u Hz, Bit Rate %d\n",
-					codec.id, codec.ch_in, codec.sample_rate, codec.bit_rate);
+				compress_print_playback_info(name, card, device,
+							     allocated_buffer_size,
+							     num_fragments, &codec);
 
 				compress_start(compress);
 				if (verbose)

--- a/src/utils-lgpl/fcplay.c
+++ b/src/utils-lgpl/fcplay.c
@@ -452,8 +452,8 @@ void play_samples(char **files, unsigned int card, unsigned int device,
 		compress_set_gapless_metadata(compress, &mdata);
 	}
 
-	compress_print_playback_info(name, card, device, allocated_buffer_size,
-				     num_fragments, &codec);
+	compress_print_playback_info(name, card, device, file_count, file_idx,
+				     allocated_buffer_size, num_fragments, &codec);
 
 	compress_start(compress);
 	if (verbose)
@@ -465,10 +465,6 @@ void play_samples(char **files, unsigned int card, unsigned int device,
 			file = fopen(name, "rb");
 			if (!file)
 				goto TRACK_EXIT;
-
-			if (verbose)
-				printf("Playing file %s On Card %u device %u, with buffer of %lu bytes, %u fragments\n",
-				       name, card, device, allocated_buffer_size, num_fragments);
 
 			if (pb_mode == PLAYBACK_MODE_GAPLESS) {
 				int rc;
@@ -491,6 +487,11 @@ void play_samples(char **files, unsigned int card, unsigned int device,
 				rc = compress_partial_drain(compress);
 				if (rc)
 					fprintf(stderr, "ERR: partial drain\n");
+
+				compress_print_playback_info(name, card, device,
+							     file_count, file_idx,
+							     allocated_buffer_size,
+							     num_fragments, &codec);
 			} else if (pb_mode == PLAYBACK_MODE_RESTART) {
 				/* restart: drain, close, and reopen for the new file */
 				compress_drain(compress);
@@ -509,12 +510,16 @@ void play_samples(char **files, unsigned int card, unsigned int device,
 				fragment_size = num_fragments ? (int)(allocated_buffer_size / num_fragments) : 0;
 
 				compress_print_playback_info(name, card, device,
+							     file_count, file_idx,
 							     allocated_buffer_size,
 							     num_fragments, &codec);
 
 				compress_start(compress);
 				if (verbose)
 					printf("%s: You should hear audio NOW!!!\n", __func__);
+			} else if (verbose) {
+				printf("Playing file %s On Card %u device %u, with buffer of %lu bytes, %u fragments\n",
+				       name, card, device, allocated_buffer_size, num_fragments);
 			}
 		}
 

--- a/src/utils-lgpl/fcplay.c
+++ b/src/utils-lgpl/fcplay.c
@@ -351,8 +351,8 @@ exit:
 static struct compress *
 compress_open_and_prepare(unsigned int card, unsigned int device,
 			  struct snd_codec *codec, unsigned long buffer_size,
-			  const char *name, FILE *file, char **buffer_out,
-			  int *size_out)
+			  unsigned int frag, const char *name, FILE *file,
+			  char **buffer_out, int *size_out)
 {
 	struct compr_config config;
 	struct compress *compress;
@@ -361,6 +361,14 @@ compress_open_and_prepare(unsigned int card, unsigned int device,
 
 	memset(&config, 0, sizeof(config));
 
+	if ((buffer_size != 0) && (frag != 0)) {
+		config.fragment_size = buffer_size / frag;
+		config.fragments = frag;
+	} else {
+		/* use driver defaults */
+		config.fragment_size = 0;
+		config.fragments = 0;
+	}
 	config.codec = codec;
 
 	compress = compress_open(card, device, COMPRESS_IN, &config);
@@ -428,7 +436,7 @@ void play_samples(char **files, unsigned int card, unsigned int device,
 
 	parse_file(name, &codec);
 	compress = compress_open_and_prepare(card, device, &codec, buffer_size,
-					     name, file, &buffer, &size);
+					     frag, name, file, &buffer, &size);
 	if (!compress)
 		goto FILE_EXIT;
 
@@ -486,7 +494,7 @@ void play_samples(char **files, unsigned int card, unsigned int device,
 
 				parse_file(name, &codec);
 				compress = compress_open_and_prepare(card, device, &codec,
-								     buffer_size, name,
+								     buffer_size, frag, name,
 								     file, &buffer, &size);
 				if (!compress)
 					goto FILE_EXIT;

--- a/src/utils/cplay.c
+++ b/src/utils/cplay.c
@@ -844,8 +844,8 @@ void play_samples(char *name, unsigned int card, unsigned int device,
 			fprintf(stderr, "We wrote %d, DSP accepted %d\n", num_read, wrote);
 		}
 	}
-	printf("Playing file %s On Card %u device %u, with buffer of %d bytes\n",
-			name, card, device, size);
+	printf("Playing file %s On Card %u device %u, with buffer of %d bytes, %u fragments\n",
+			name, card, device, size, config.fragments);
 	printf("Format %u Channels %u, %u Hz, Bit Rate %d\n",
 			codec.id, codec.ch_in, codec.sample_rate, codec.bit_rate);
 

--- a/src/utils/cplay.c
+++ b/src/utils/cplay.c
@@ -844,8 +844,8 @@ void play_samples(char *name, unsigned int card, unsigned int device,
 			fprintf(stderr, "We wrote %d, DSP accepted %d\n", num_read, wrote);
 		}
 	}
-	compress_print_playback_info(name, card, device,
-				     (unsigned long)size, config.fragments, &codec);
+	compress_print_playback_info(name, card, device, 1, 0, (unsigned long)size,
+				     config.fragments, &codec);
 
 	compress_start(compress);
 	if (verbose)

--- a/src/utils/cplay.c
+++ b/src/utils/cplay.c
@@ -844,10 +844,8 @@ void play_samples(char *name, unsigned int card, unsigned int device,
 			fprintf(stderr, "We wrote %d, DSP accepted %d\n", num_read, wrote);
 		}
 	}
-	printf("Playing file %s On Card %u device %u, with buffer of %d bytes, %u fragments\n",
-			name, card, device, size, config.fragments);
-	printf("Format %u Channels %u, %u Hz, Bit Rate %d\n",
-			codec.id, codec.ch_in, codec.sample_rate, codec.bit_rate);
+	compress_print_playback_info(name, card, device,
+				     (unsigned long)size, config.fragments, &codec);
 
 	compress_start(compress);
 	if (verbose)


### PR DESCRIPTION
Fix fcplay to take the buffer and fragments parameter into account (it is ignored currently)
Make the prints about buffer configuration more informative and common between cplay and fcplay
During multiple file playback with fcplay print out the new file when the changeover happens.
